### PR TITLE
Upgraded packages to reduce npm critical vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,12 @@
     "optimist": "0.6.1",
     "passerror": "1.1.0",
     "relaxed-json": "1.0.3",
-    "underscore": "*"
+    "underscore": "^1.13.6"
   },
   "devDependencies": {
     "coveralls": "^3.0.3",
     "eslint": "^5.16.0",
-    "mocha": "^6.1.4",
+    "mocha": "^10.2.0",
     "nyc": "^14.0.0",
     "unexpected": "10.15.0"
   }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "async": "0.9.0",
-    "cjson": "0.3.1",
+    "cjson": "^0.5.0",
     "glob": "^7.1.3",
     "minimatch": "^3.0.4",
     "optimist": "0.6.1",

--- a/test/bin/oconf-lint.spec.js
+++ b/test/bin/oconf-lint.spec.js
@@ -55,10 +55,9 @@ describe('bin/oconf-lint', function () {
             code: 1,
             stdout: '',
             stderr: [
-                'Error: Parse error on line 2:',
-                '{    "foo": "bar}',
-                '------------^',
-                'Expecting \'STRING\', \'NUMBER\', \'NULL\', \'TRUE\', \'FALSE\', \'{\', \'[\', got \'undefined\'',
+                'Error: Unexpected token \'}\' at 2:17',
+                '    "foo": "bar',
+                '               ^',
                 'File: "' + filePath + '"',
                 ''
             ].join('\n')

--- a/test/bin/oconf.spec.js
+++ b/test/bin/oconf.spec.js
@@ -142,10 +142,9 @@ describe('bin/oconf', function () {
                 err: expect.it('to be an', Error),
                 stdout: '',
                 stderr: [
-                    'Error: Parse error on line 2:',
-                    '{    "foo": "bar}',
-                    '------------^',
-                    'Expecting \'STRING\', \'NUMBER\', \'NULL\', \'TRUE\', \'FALSE\', \'{\', \'[\', got \'undefined\'',
+                    'Error: Unexpected token \'}\' at 2:17',
+                    '    "foo": "bar',
+                    '               ^',
                     'File: "' + filePath + '"',
                     ''
                 ].join('\n')

--- a/test/lib/lint.spec.js
+++ b/test/lib/lint.spec.js
@@ -33,7 +33,7 @@ describe('lib/lint', function () {
     });
     it('should complain when given an invalid file', function (done) {
         lint(testData('invalid.cjson'), function (err) {
-            expect(err, 'to be an error', /^Parse error on line 2:/);
+            expect(err, 'to be an error', /^Unexpected token '.' at 2:/);
             done();
         });
     });
@@ -47,7 +47,7 @@ describe('lib/lint', function () {
         it('should complain if at least one file is invalid', function (done) {
             lint(testData('invalidDirectory'), function (err) {
                 expect(err, 'to satisfy', {
-                    message: /^Parse error on line 2:/,
+                    message: /^Unexpected token '.' at 2:/,
                     file: /invalidDirectory\/2.cjson$/
                 });
                 done();


### PR DESCRIPTION
Upgraded the following packages:
> mocha
> underscore
> oconf

Also fixed 4 test cases which were failing due to oconf upgrade.

After upgrades,
* All tests are passing
* 5 critical, 1 high & 1 moderate vulnerabilities have been resolved