### PR TITLE
Replace optimist with commander

### DIFF
--- a/bin/oconf
+++ b/bin/oconf
@@ -46,8 +46,7 @@ if (!argv['extractOption'] && (argv['optionAsJson'] || argv['allowMissingOption'
         console.error('The flag --allow-missing-option does not make sense without the --extract-option flag.');
     }
 
-    // console.error('');
-    // console.error(program.help());
+    program.help();
     process.exit(1);
 }
 

--- a/bin/oconf
+++ b/bin/oconf
@@ -1,57 +1,30 @@
 #!/usr/bin/env node
-var oconf = require('../lib/index');
+const oconf = require('../lib/index');
+const { Command } = require('commander');
+const program = new Command();
 
-var argp = require('optimist')
-    .usage('Usage: $0 [--lint|--extract-option <option> [--allow-missing-option][--option-as-json]] <file>')
-    .option('help', {
-        alias: 'h',
-        description: 'This help text.',
-        type: 'boolean'
-    })
-    .option('ignore', {
-        alias: 'i',
-        description: 'Absolute path or glob pattern for ignoring included files.',
-        type: 'string'
-    })
-    .option('lint', {
-        alias: 'l',
-        description: 'Lint the input file and report any errors.',
-        type: 'boolean'
-    })
-    .option('relaxed', {
-        alias: 'r',
-        description: 'Use relaxed JSON format.',
-        type: 'boolean'
-    })
-    .option('extract-option', {
-        alias: 'o',
-        description: 'Extract the value of an option.',
-        type: 'string'
-	})
-    .option('option-as-json', {
-        alias: 'j',
-        description: 'The extracted value will be extracted as JSON.',
-        type: 'boolean'
-    })
-    .option('public', {
-        alias: 'p',
-        description: 'Only values in #public objects will be extracted.',
-        type: 'boolean'
-    })
-    .option('json', { type: 'boolean' })
-    .option('allow-missing-option', {
-        alias: 'm',
-        description: 'Do not fail when no such value is present.',
-        type: 'boolean'
-    })
-    .option('allowmissing', { type: 'boolean' });
+program
+    .name('oconf')
+    .usage('[--lint|--extractOption <option> [--allowMissingOption][--optionAsJson]] <file>')
+    .option('-h, --help', 'This help text.')
+    .option('-i, --ignore <path>', 'Absolute path or glob pattern for ignoring included files.')
+    .option('-l, --lint', 'Lint the input file and report any errors.')
+    .option('-r, --relaxed', 'Use relaxed JSON format.')
+    .option('-p, --public', 'Only values in #public objects will be extracted.')
+    .option('-o, --extract-option <option>', 'Extract the value of an option.')
+    .option('-j, --option-as-json', 'The extracted value will be extracted as JSON.')
+    .option('-m, --allow-missing-option', 'Do not fail when no such value is present.')
+    .option('--json', 'JSON output.')
+    .option('--allowmissing', 'Allow missing options.')
+    .parse();
 
-var argv = argp.argv;
+const argv = program.opts();
+argv._ = program.args;
 
 // This is needed as optimist will not force exit when --help is
 // passed on it's own, and we want it to.
 if (argv.help || argv._.length < 1) {
-    argp.showHelp();
+    program.help();
     process.exit(0);
 }
 
@@ -59,22 +32,22 @@ if (argv.help || argv._.length < 1) {
 // This is here for backwards compatibility. Used to be an okay
 // flag. We can add a deprecation warning later.
 if (argv['json']) {
-    argv['option-as-json'] = true;
+    argv['optionAsJson'] = true;
 }
 if (argv['allowmissing']) {
-    argv['allow-missing-option'] = true;
+    argv['allowMissingOption'] = true;
 }
 //////////////////////////////////////////////////////////////////
 
-if (!argv['extract-option'] && (argv['option-as-json'] || argv['allow-missing-option'])) {
-    if (argv['option-as-json']) {
+if (!argv['extractOption'] && (argv['optionAsJson'] || argv['allowMissingOption'])) {
+    if (argv['optionAsJson']) {
         console.error('The flag --option-as-json does not make sense without the --extract-option flag.');
-    } else if (argv['allow-missing-option']) {
+    } else if (argv['allowMissingOption']) {
         console.error('The flag --allow-missing-option does not make sense without the --extract-option flag.');
     }
 
-    console.error('');
-    argp.showHelp();
+    // console.error('');
+    // console.error(program.help());
     process.exit(1);
 }
 
@@ -89,11 +62,11 @@ function _getKey(keyname, testObj) {
         return {error: 'Not found'};
     }
 
-    var key = keyname.shift();
+    const key = keyname.shift();
 
     // Is it an object -- and does it have the key
     if (testObj !== new Object(testObj) || !(key in testObj)) {
-        if (argv['allow-missing-option']) {
+        if (argv['allowMissingOption']) {
             process.exit(0);
         }
         throw new Error('Key ' + key + ' not found in ' + JSON.stringify(testObj));
@@ -108,7 +81,7 @@ function _getKey(keyname, testObj) {
     return testObj[key];
 }
 
-var config;
+let config;
 
 try {
     config = oconf.load(argv._, { ignore: argv.ignore, public: argv.public, relaxed: argv.relaxed });
@@ -122,21 +95,21 @@ if (argv.lint) {
     process.exit(0);
 }
 
-if (argv['extract-option']) {
+if (argv['extractOption']) {
     try {
-        var data = config;
+        let data = config;
 
-        data = _getKey(argv['extract-option'], data);
+        data = _getKey(argv['extractOption'], data);
 
-        if (!argv['option-as-json'] && Array.isArray(data)) {
+        if (!argv['optionAsJson'] && Array.isArray(data)) {
             data = data.join(' ');
-        } else if (argv['option-as-json'] || (typeof data !== 'string' && typeof data !== 'number')) {
+        } else if (argv['optionAsJson'] || (typeof data !== 'string' && typeof data !== 'number')) {
             data = JSON.stringify(data, false, 4);
         }
 
         console.log(data);
     } catch (error) {
-        if (!argv['allow-missing-option']) {
+        if (!argv['allowMissingOption']) {
             console.error("Error:", error.message);
             process.exit(1);
         }

--- a/bin/oconf
+++ b/bin/oconf
@@ -24,7 +24,7 @@ argv._ = program.args;
 // This is needed as optimist will not force exit when --help is
 // passed on it's own, and we want it to.
 if (argv.help || argv._.length < 1) {
-    program.help();
+    program.outputHelp();
     process.exit(0);
 }
 
@@ -45,8 +45,9 @@ if (!argv['extractOption'] && (argv['optionAsJson'] || argv['allowMissingOption'
     } else if (argv['allowMissingOption']) {
         console.error('The flag --allow-missing-option does not make sense without the --extract-option flag.');
     }
-
-    program.help();
+    
+    console.error('');
+    program.outputHelp();
     process.exit(1);
 }
 

--- a/bin/oconf
+++ b/bin/oconf
@@ -5,7 +5,7 @@ const program = new Command();
 
 program
     .name('oconf')
-    .usage('[--lint|--extractOption <option> [--allowMissingOption][--optionAsJson]] <file>')
+    .usage('[--lint|--extract-option <option> [--allow-missing-option][--option-as-json]] <file>')
     .option('-h, --help', 'This help text.')
     .option('-i, --ignore <path>', 'Absolute path or glob pattern for ignoring included files.')
     .option('-l, --lint', 'Lint the input file and report any errors.')

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   "dependencies": {
     "async": "0.9.0",
     "cjson": "^0.5.0",
+    "commander": "^12.1.0",
     "glob": "^7.1.3",
     "minimatch": "^3.0.4",
-    "optimist": "0.6.1",
     "passerror": "1.1.0",
     "relaxed-json": "1.0.3",
     "underscore": "^1.13.6"

--- a/test/bin/oconf.spec.js
+++ b/test/bin/oconf.spec.js
@@ -1,5 +1,6 @@
 /* global describe, it */
 var exec = require('child_process').exec;
+const { stdout } = require('process');
 var expect = require('unexpected');
 
 var pathToBin = require('path').resolve(__dirname, '../../bin/', 'oconf');
@@ -272,7 +273,8 @@ describe('bin/oconf', function () {
                 '--lint',
                 '--allow-missing-option'
             ], 'when passed as arguments to oconf', 'to satisfy', {
-                code: 1,
+                code: 0,
+                stdout: /Usage:/,
                 stderr: /^The flag --allow-missing-option does not make sense/
             });
         });
@@ -282,7 +284,8 @@ describe('bin/oconf', function () {
                 '--lint',
                 '--option-as-json'
             ], 'when passed as arguments to oconf', 'to satisfy', {
-                code: 1,
+                code: 0,
+                stdout: /Usage:/,
                 stderr: /^The flag --option-as-json does not make sense/
             });
         });
@@ -291,7 +294,8 @@ describe('bin/oconf', function () {
                 'foo.cjson',
                 '--option-as-json'
             ], 'when passed as arguments to oconf', 'to satisfy', {
-                code: 1,
+                code: 0,
+                stdout: /Usage:/,
                 stderr: /^The flag --option-as-json does not make sense/
             });
         });

--- a/test/bin/oconf.spec.js
+++ b/test/bin/oconf.spec.js
@@ -117,8 +117,8 @@ describe('bin/oconf', function () {
             return expect('--help', 'when passed as arguments to oconf', 'to satisfy', {
                 err: null,
                 code: 0,
-                stdout: '',
-                stderr: expect.it('to match', /Options/)
+                stdout: expect.it('to match', /Options/),
+                stderr: ''
             });
         });
     });

--- a/test/bin/oconf.spec.js
+++ b/test/bin/oconf.spec.js
@@ -1,6 +1,5 @@
 /* global describe, it */
 var exec = require('child_process').exec;
-const { stdout } = require('process');
 var expect = require('unexpected');
 
 var pathToBin = require('path').resolve(__dirname, '../../bin/', 'oconf');
@@ -273,8 +272,7 @@ describe('bin/oconf', function () {
                 '--lint',
                 '--allow-missing-option'
             ], 'when passed as arguments to oconf', 'to satisfy', {
-                code: 0,
-                stdout: /Usage:/,
+                code: 1,
                 stderr: /^The flag --allow-missing-option does not make sense/
             });
         });
@@ -284,8 +282,7 @@ describe('bin/oconf', function () {
                 '--lint',
                 '--option-as-json'
             ], 'when passed as arguments to oconf', 'to satisfy', {
-                code: 0,
-                stdout: /Usage:/,
+                code: 1,
                 stderr: /^The flag --option-as-json does not make sense/
             });
         });
@@ -294,8 +291,7 @@ describe('bin/oconf', function () {
                 'foo.cjson',
                 '--option-as-json'
             ], 'when passed as arguments to oconf', 'to satisfy', {
-                code: 0,
-                stdout: /Usage:/,
+                code: 1,
                 stderr: /^The flag --option-as-json does not make sense/
             });
         });

--- a/test/lib/index.spec.js
+++ b/test/lib/index.spec.js
@@ -246,7 +246,7 @@ describe('#public behaviour', function () {
             before(function () {
                 data = oconf.load(testFile('array-with-object-with-array-with-object-with-public.cjson'));
             });
-            it.skip('should fold the #public properties down into the base structure', function () {
+            it('should fold the #public properties down into the base structure', function () {
                 expect(data, 'to exhaustively satisfy', {
                     0: {
                         foo: [


### PR DESCRIPTION
The npm package [optimist](https://www.npmjs.com/package/optimist) is deprecated.


This PR replaces optimist with [commander](https://www.npmjs.com/package/commander).